### PR TITLE
Script improved to get closer to production use

### DIFF
--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -80,11 +80,14 @@ if [ ! -d $poco ]; then
 fi
 
 ######## Poco Build ########
-cd "$poco"
-sudo -u lool ./configure | tee -a $log_file
-sudo -u lool make -j${cpu} | tee -a $log_file
-make install | tee -a $log_file
-
+## test if the poco poco has already been compiled
+# (the dir size should be around 450000ko vs 65000ko when no compilation)
+if [ $(du -s ${poco} | awk '{print $1}') -gt 100000 ]; then
+  cd "$poco"
+  sudo -u lool ./configure | tee -a $log_file
+  sudo -u lool make -j${cpu} | tee -a $log_file
+  make install | tee -a $log_file
+fi
 ###############################################################################
 ######## loolwsd Build ########
 #### Download dependencies ####

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #VERSION 1.5.1
 #Written by: Subhi H.
+#Github Contributors: Aalaesar, Kassiematis, morph027
 #This script is free software: you can redistribute it and/or modify it under
 #the terms of the GNU General Public License as published by the Free Software
 #Foundation, either version 3 of the License, or (at your option) any later version.

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -46,7 +46,7 @@ lool_maxdoc=100
 # run apt update && upgrade if last update is older than 1 day
 find /var/lib/apt/lists/ -mtime -1 |grep -q partial || apt-get update && apt-get upgrade -y
 
-[ ${lo_forcebuild} ] && apt-get install dialog -y
+[ ${sh_interactive} ] && apt-get install dialog -y
 
 grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get update
 
@@ -87,7 +87,7 @@ fi
 
 # build LibreOffice if it has'nt been built already or lo_forcebuild is true
 if [ ! -d ${lo_dir}/instdir ] || ${lo_forcebuild}; then
-  if [ ${lo_forcebuild} ]; then
+  if [ ${sh_interactive} ]; then
     dialog --backtitle "Information" \
     --title "${lo_version} is going to be built." \
     --msgbox "THE COMPILATION WILL TAKE REALLY A VERY LONG TIME,\nAROUND $((8/${cpu})) HOURS (Depending on your CPU's speed),\n"\

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -93,9 +93,12 @@ if [ ! -d ${lo_dir}/instdir ] || ${lo_forcebuild}; then
 "SO BE PATIENT PLEASE! ! You may see errors during the installation, just ignore them and let it do the work." 10 78
     clear
   fi
-  sudo -u lool bash -c "cd ${lo_dir} && ./autogen.sh --without-help --without-myspell-dicts" | tee -a $log_file
+  cd ${lo_dir}
+  sudo -Hu lool ./autogen.sh --without-help --without-myspell-dicts | tee -a $log_file
+  [ ${PIPESTATUS[0]} -ne 0 ] && exit 2
   # libreoffice take around 8/${cpu} hours to compile on fast cpu.
-  sudo -u lool bash -c "cd ${lo_dir} && make" | tee -a $log_file
+  sudo -Hu lool make | tee -a $log_file
+  [ ${PIPESTATUS[0]} -ne 0 ] && exit 2
 fi
 
 ###############################################################################
@@ -116,10 +119,13 @@ fi
 # so let say arbitrary : do compilation when folder size is less than 100Mo
 if [ $(du -s ${poco} | awk '{print $1}') -lt 100000 ]; then
   cd "$poco"
-  sudo -u lool ./configure | tee -a $log_file
-  sudo -u lool make -j${cpu} | tee -a $log_file
+  sudo -Hu lool ./configure | tee -a $log_file
+  [ ${PIPESTATUS[0]} -ne 0 ] && exit 3
+  sudo -Hu lool make -j${cpu} | tee -a $log_file
+  [ ${PIPESTATUS[0]} -ne 0 ] && exit 3
   # poco take around 22/${cpu} minutes to compile on fast cpu
   make install | tee -a $log_file
+  [ ${PIPESTATUS[0]} -ne 0 ] && exit 3
 fi
 ###############################################################################
 ########################### loolwsd Installation ##############################
@@ -156,12 +162,13 @@ if [ -f /etc/sudoers ] && ! grep -q 'lool' /etc/sudoers; then
   fi
 fi
 cd ${lool_dir}
-[ -f ${lool_dir}/loolwsd ] && sudo -u lool make clean
-sudo -u lool ./autogen.sh
+[ -f ${lool_dir}/loolwsd ] && sudo -Hu lool make clean
+sudo -Hu lool ./autogen.sh
 [ -n "${lool_logfile}" ] && lool_configure_opts="${lool_configure_opts} --with-logfile=${lool_logfile}"
-sudo -u lool bash -c "./configure --enable-silent-rules --with-lokit-path=${lool_dir}/bundled/include --with-lo-path=${lo_dir}/instdir --with-max-connections=$lool_maxcon --with-max-documents=$lool_maxdoc --with-poco-includes=/usr/local/include --with-poco-libs=/usr/local/lib ${lool_configure_opts}" | tee -a $log_file
+sudo -Hu lool bash -c "./configure --enable-silent-rules --with-lokit-path=${lool_dir}/bundled/include --with-lo-path=${lo_dir}/instdir --with-max-connections=$lool_maxcon --with-max-documents=$lool_maxdoc --with-poco-includes=/usr/local/include --with-poco-libs=/usr/local/lib ${lool_configure_opts}" | tee -a $log_file
+[ ${PIPESTATUS[0]} -ne 0 ] && exit 4
 # loolwsd+loleaflet take around 8.5/${cpu} minutes to compile on fast cpu
-sudo -u lool bash -c "make -j$cpu --directory=${lool_dir}" | tee -a $log_file
+sudo -Hu lool make -j$cpu --directory=${lool_dir} | tee -a $log_file
 _loolwsd_make_rc=${?} # get the make return code
 ### remove lool group from sudoers
 if [ -f /etc/sudoers ]; then
@@ -220,7 +227,7 @@ if [ ${sh_interactive} ]; then
 "after that run (systemctl daemon-reload && systemctl restart loolwsd.service).\nPlease press OK and wait 15 sec. I will start the service." 10 145
   clear
 fi
-sudo -u lool bash -c "${lool_dir}/loolwsd --o:sys_template_path=${lool_dir}/systemplate --o:lo_template_path=${lo_dir}/instdir  --o:child_root_path=${lool_dir}/jails --o:storage.filesystem[@allow]=true --o:admin_console.username=admin --o:admin_console.password=admin &"
+sudo -Hu lool bash -c "${lool_dir}/loolwsd --o:sys_template_path=${lool_dir}/systemplate --o:lo_template_path=${lo_dir}/instdir  --o:child_root_path=${lool_dir}/jails --o:storage.filesystem[@allow]=true --o:admin_console.username=admin --o:admin_console.password=admin &"
 rm -rf ${lo_dir}/workdir
 sleep 10
 ps -u lool | grep loolwsd

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -93,13 +93,14 @@ echo "%lool ALL=NOPASSWD:ALL" >> /etc/sudoers
 
 chown -R lool:lool {$ooo,$poco,$oo}
 
-mkdir -p /usr/local/var/cache/loolwsd
-chown -R lool:lool /usr/local/var/cache/loolwsd
 
 PASSWORD=$(randpass 10 0)
 
-cat <<EOT > /lib/systemd/system/loolwsd.service
+mkdir -p /usr/local/var/cache/loolwsd && chown -R lool:lool /usr/local/var/cache/loolwsd
 
+if [ ! -f /lib/systemd/system/loolwsd.service ]; then
+  PASSWORD=$(randpass 10 0)
+  cat <<EOT > /lib/systemd/system/loolwsd.service
 [Unit]
 Description=LibreOffice OnLine WebSocket Daemon
 After=network.target
@@ -117,6 +118,7 @@ KillMode=control-group
 [Install]
 WantedBy=multi-user.target
 EOT
+fi
 
 if [ ! -f /etc/loolwsd/ca-chain.cert.pem ]; then
   mkdir /etc/loolwsd

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -29,7 +29,6 @@ sh_interactive=true
 
 ### LibreOffice parameters ###
 lo_src_repo='http://download.documentfoundation.org/libreoffice/src'
-lo_major_v='' #5.3.1
 lo_version='' #5.3.1.2
 lo_dir="/opt/libreoffice"
 lo_forcebuild=false
@@ -67,8 +66,10 @@ chown lool:lool /home/lool -R
 ######################## libreoffice compilation ##############################
 #verify what version need to be downloaded if no version has been defined in config
 if [ -z "${lo_version}" ];then
-  [ -z "${lo_major_v}" ] && lo_major_v=$(curl -s ${lo_src_repo}/ | grep -oiE '^.*href="([0-9+]\.)+[0-9]/"'| tail -1 | sed 's/.*href="\(.*\)\/"$/\1/')
+  lo_major_v=$(curl -s ${lo_src_repo}/ | grep -oiE '^.*href="([0-9+]\.)+[0-9]/"'| tail -1 | sed 's/.*href="\(.*\)\/"$/\1/')
   lo_version=$(curl -s ${lo_src_repo}/${lo_major_v}/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
+else
+  lo_major_v=$(echo ${lo_version} | cut -d '.' -f1-3)
 fi
 # check is libreoffice sources are already present and in the correct version
 if [ -d ${lo_dir} ]; then

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -158,7 +158,6 @@ if [ ! -f /etc/loolwsd/ca-chain.cert.pem ]; then
 fi
 if [! -e /etc/systemd/system/loolwsd.service ]; then
   ln /lib/systemd/system/loolwsd.service /etc/systemd/system/loolwsd.service
-  systemctl enable loolwsd.service
 fi
 ### Testing loolwsd ###
 dialog --backtitle "Information" \
@@ -169,12 +168,17 @@ after that run (systemctl daemon-reload && systemctl restart loolwsd.service). P
 
 clear
 
-sudo -H -u lool bash -c "for dir in ./ ; do ( cd "$oo" && make run & ); done"
+sudo -u lool bash -c "${oo}/loolwsd --o:sys_template_path=${oo}/systemplate --o:lo_template_path=${ooo}/instdir  --o:child_root_path=${oo}/jails --o:storage.filesystem[@allow]=true --o:admin_console.username=admin --o:admin_console.password=admin &"
 rm -rf ${ooo}/workdir
-echo "Please wait, I am checking if lool service is running...."
-sleep 17
-
-ps -ef | grep loolwsd | grep -v grep
-[ $?  -eq "0" ] && echo -e "\033[33;7m### loolwsd is running. Enjoy!!! ###\033[0m" || echo -e "\033[33;5m### loolwsd is not running. Something went wrong :| Please look in ${log_file} ###\033[0m"
+sleep 10
+ps -u lool | grep loolwsd
+if [ $?  -eq "0" ]; then
+  echo -e "\033[33;7m### loolwsd is running. Enjoy!!! ###\033[0m"
+  ps -u lool -o pid,cmd | grep loolwsd |awk '{print $1}' | xargs kill
+  systemctl start loolwsd
+  systemctl enable loolwsd.service
+else
+  echo -e "\033[33;5m### loolwsd is not running. Something went wrong :| Please look in ${log_file} ###\033[0m"
+fi
 lsof -i :9980
 exit

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -76,7 +76,7 @@ sudo -H -u lool bash -c "for dir in ./ ; do (cd "$oo" && libtoolize && aclocal &
 for dir in ./ ; do (cd "$oo" && npm install -g npm); done
 for dir in ./ ; do (cd "$oo" && npm install -g jake); done
 
-for dir in ./ ; do ( cd "$oo" && ./configure --enable-silent-rules --with-lokit-path=/opt/online/bundled/include --with-lo-path=/opt/libreoffice/instdir --with-max-connections=$maxcon --with-max-documents=$maxdoc --with-poco-includes=/usr/local/include --with-poco-libs=/usr/local/lib --enable-debug && make -j$cpu --directory=$oo); done | tee -a $log_file
+for dir in ./ ; do ( cd "$oo" && ./configure --enable-silent-rules --with-lokit-path=${oo}/bundled/include --with-lo-path=${ooo}/instdir --with-max-connections=$maxcon --with-max-documents=$maxdoc --with-poco-includes=/usr/local/include --with-poco-libs=/usr/local/lib --enable-debug && make -j$cpu --directory=$oo); done | tee -a $log_file
 for dir in ./ ; do ( cd "$oo" && make install); done | tee -a $log_file
 
 echo "%lool ALL=NOPASSWD:ALL" >> /etc/sudoers
@@ -99,7 +99,7 @@ EnvironmentFile=-/etc/sysconfig/loolwsd
 ExecStartPre=/bin/mkdir -p /usr/local/var/cache/loolwsd
 ExecStartPre=/bin/chown lool: /usr/local/var/cache/loolwsd
 PermissionsStartOnly=true
-ExecStart=/opt/online/loolwsd --o:sys_template_path=/opt/online/systemplate --o:lo_template_path=/opt/libreoffice/instdir  --o:child_root_path=/opt/online/jails --o:storage.filesystem[@allow]=true --o:admin_console.username=admin --o:admin_console.password=$PASSWORD
+ExecStart=${oo}/loolwsd --o:sys_template_path=${oo}/systemplate --o:lo_template_path=${ooo}/instdir  --o:child_root_path=${oo}/jails --o:storage.filesystem[@allow]=true --o:admin_console.username=admin --o:admin_console.password=$PASSWORD
 User=lool
 KillMode=control-group
 Restart=always
@@ -126,12 +126,12 @@ after that run (systemctl daemon-reload && systemctl restart loolwsd.service). P
 clear
 
 sudo -H -u lool bash -c "for dir in ./ ; do ( cd "$oo" && make run & ); done"
-rm -rf /opt/libreoffice/workdir
+rm -rf ${ooo}/workdir
 echo "Please wait, I am checking if lool service is running...."
 sleep 17
 
 sed -i '$d' /etc/sudoers
 ps -ef | grep loolwsd | grep -v grep
-[ $?  -eq "0" ] && echo -e "\033[33;7m### loolwsd is running. Enjoy!!! ###\033[0m" || echo -e "\033[33;5m### loolwsd is not running. Something went wrong :| Please look in /tmp/officeonline.log ###\033[0m"
+[ $?  -eq "0" ] && echo -e "\033[33;7m### loolwsd is running. Enjoy!!! ###\033[0m" || echo -e "\033[33;5m### loolwsd is not running. Something went wrong :| Please look in ${log_file} ###\033[0m"
 lsof -i :9980
 exit

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -19,6 +19,7 @@ randpass() {
 }
 clear
 
+# lo_major_v=5.3.1
 soli="/etc/apt/sources.list"
 log_file="/tmp/officeonline.log"
 ooo="/opt/libreoffice"
@@ -53,8 +54,9 @@ getent passwd lool || (useradd lool -G sudo; mkdir /home/lool)
 chown lool:lool /home/lool -R
 
 if [ ! -f ${ooo}/autogen.sh ]; then
-  lo_version=$(curl -s http://download.documentfoundation.org/libreoffice/src/5.3.0/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
-  [ ! -f $lo_version.tar.xz ] && wget -c http://download.documentfoundation.org/libreoffice/src/5.3.0/$lo_version.tar.xz -P /opt/
+  [ -z "${lo_major_v}" ] && lo_major_v=$(curl -s http://download.documentfoundation.org/libreoffice/src/ | grep -oiE '^.*href="([0-9+]\.)+[0-9]/"'| tail -1 | sed 's/.*href="\(.*\)\/"$/\1/')
+  lo_version=$(curl -s http://download.documentfoundation.org/libreoffice/src/${lo_major_v}/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
+  [ ! -f $lo_version.tar.xz ] && wget -c http://download.documentfoundation.org/libreoffice/src/${lo_major_v}/$lo_version.tar.xz -P /opt/
   [ ! -d $lo_version ] && tar xf /opt/$lo_version.tar.xz -C  /opt/
   mv /opt/$lo_version $ooo
   chown lool:lool $ooo -R

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -1,6 +1,4 @@
-
 #!/bin/bash
-
 #VERSION 1.5.1
 #Written by: Subhi H.
 #This script is free software: you can redistribute it and/or modify it under
@@ -19,7 +17,6 @@ randpass() {
   [ "$2" == "0" ] && CHAR="[:alnum:]" || CHAR="[:graph:]"
   cat /dev/urandom 2>/dev/null | tr -cd "$CHAR" 2>/dev/null | head -c ${1:-32}
 }
-
 clear
 
 soli="/etc/apt/sources.list"
@@ -30,8 +27,10 @@ cpu=$(nproc)
 maxcon=200
 maxdoc=100
 
-apt-get update && apt-get -y install dialog
+# run apt update && upgrade if last update is older than 1 day
+find /var/lib/apt/lists/ -mtime -1 |grep -q partial || apt-get update && apt-get upgrade -y
 
+apt-get install dialog -y
 dialog --backtitle "Information" \
 --title "Note" \
 --msgbox 'THE INSTALLATION WILL TAKE REALLY VERY LONG TIME, 2-8 HOURS (It depends on the speed of your server), SO BE PATIENT PLEASE!!! You may see errors during the installation, just ignore them and let it do the work.' 10 78

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -20,6 +20,7 @@ randpass() {
 clear
 
 # lo_major_v=5.3.1
+lo_src_repo='http://download.documentfoundation.org/libreoffice/src'
 soli="/etc/apt/sources.list"
 log_file="/tmp/officeonline.log"
 ooo="/opt/libreoffice"
@@ -54,9 +55,9 @@ getent passwd lool || (useradd lool -G sudo; mkdir /home/lool)
 chown lool:lool /home/lool -R
 
 if [ ! -f ${ooo}/autogen.sh ]; then
-  [ -z "${lo_major_v}" ] && lo_major_v=$(curl -s http://download.documentfoundation.org/libreoffice/src/ | grep -oiE '^.*href="([0-9+]\.)+[0-9]/"'| tail -1 | sed 's/.*href="\(.*\)\/"$/\1/')
-  lo_version=$(curl -s http://download.documentfoundation.org/libreoffice/src/${lo_major_v}/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
-  [ ! -f $lo_version.tar.xz ] && wget -c http://download.documentfoundation.org/libreoffice/src/${lo_major_v}/$lo_version.tar.xz -P /opt/
+  [ -z "${lo_major_v}" ] && lo_major_v=$(curl -s ${lo_src_repo}/ | grep -oiE '^.*href="([0-9+]\.)+[0-9]/"'| tail -1 | sed 's/.*href="\(.*\)\/"$/\1/')
+  lo_version=$(curl -s ${lo_src_repo}/${lo_major_v}/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
+  [ ! -f $lo_version.tar.xz ] && wget -c ${lo_src_repo}/${lo_major_v}/$lo_version.tar.xz -P /opt/
   [ ! -d $lo_version ] && tar xf /opt/$lo_version.tar.xz -C  /opt/
   mv /opt/$lo_version $ooo
   chown lool:lool $ooo -R

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -86,9 +86,7 @@ sudo -u lool make -j${cpu} | tee -a $log_file
 make install | tee -a $log_file
 
 ###############################################################################
-
 ######## loolwsd Build ########
-cd ${oo}
 #### Download dependencies ####
 if [ ! -d $oo ]; then
   git clone https://github.com/husisusi/online $oo
@@ -114,6 +112,7 @@ if [ -f /etc/sudoers ] && ! grep -q 'lool' /etc/sudoers; then
 fi
 #####################
 #### loolwsd Build process ##
+cd ${oo}
 [ -f ${oo}/loolwsd ] || ${forcebuild_oo} && make clean
 sudo -u lool ./autogen.sh
 sudo -u lool bash -c "./configure --enable-silent-rules --with-lokit-path=${oo}/bundled/include --with-lo-path=${ooo}/instdir --with-max-connections=$maxcon --with-max-documents=$maxdoc --with-poco-includes=/usr/local/include --with-poco-libs=/usr/local/lib --enable-debug" | tee -a $log_file

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -107,7 +107,7 @@ fi
 if [ -f /etc/sudoers ] && ! grep -q 'lool' /etc/sudoers; then
   if ! grep -q '#includedir' /etc/sudoers; then
     #dirty modification
-    echo "%lool ALL=NOPASSWD:ALL" >> /etc/sudoers.d
+    echo "%lool ALL=NOPASSWD:ALL" >> /etc/sudoers
   else
     includedir=$(grep '#includedir' /etc/sudoers | awk '{print $NF}')
     grep -qri '%lool' ${includedir} || echo "%lool ALL=NOPASSWD:ALL" >> ${includedir}/99_lool

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -3,10 +3,15 @@
 
 #VERSION 1.5.1
 #Written by: Subhi H.
-#This script is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+#This script is free software: you can redistribute it and/or modify it under
+#the terms of the GNU General Public License as published by the Free Software
+#Foundation, either version 3 of the License, or (at your option) any later version.
 
-#This script is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+#This script is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+#or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#You should have received a copy of the GNU General Public License along with
+#this program. If not, see http://www.gnu.org/licenses/.
 
 if [[ `id -u` -ne 0 ]] ; then echo 'Please run me as root or "sudo ./officeonline-install.sh"' ; exit 1 ; fi
 
@@ -30,7 +35,6 @@ apt-get update && apt-get -y install dialog
 dialog --backtitle "Information" \
 --title "Note" \
 --msgbox 'THE INSTALLATION WILL TAKE REALLY VERY LONG TIME, 2-8 HOURS (It depends on the speed of your server), SO BE PATIENT PLEASE!!! You may see errors during the installation, just ignore them and let it do the work.' 10 78
-
 clear
 
 sed -i 's/# deb-src/deb-src/g' $soli

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -97,7 +97,8 @@ fi
 ######## Poco Build ########
 ## test if the poco poco has already been compiled
 # (the dir size should be around 450000ko vs 65000ko when no compilation)
-if [ $(du -s ${poco} | awk '{print $1}') -gt 100000 ]; then
+# so lets say arbitrary : do compilation when folder size is less than 100Mo
+if [ $(du -s ${poco} | awk '{print $1}') -lt 100000 ]; then
   cd "$poco"
   sudo -u lool ./configure | tee -a $log_file
   sudo -u lool make -j${cpu} | tee -a $log_file

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -36,34 +36,41 @@ dialog --backtitle "Information" \
 --msgbox 'THE INSTALLATION WILL TAKE REALLY VERY LONG TIME, 2-8 HOURS (It depends on the speed of your server), SO BE PATIENT PLEASE!!! You may see errors during the installation, just ignore them and let it do the work.' 10 78
 clear
 
-sed -i 's/# deb-src/deb-src/g' $soli
+grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get update
 
+apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev -y
+[ $? -ne 0 ] && exit 1
+apt-get build-dep libreoffice -y
 
-apt-get update && apt-get upgrade -y
-
-apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev  -y && sudo apt-get build-dep libreoffice -y
-
-curl -sL https://deb.nodesource.com/setup_6.x | bash -
-apt-get install nodejs -y
+if [ ! -f /etc/apt/sources.list.d/nodesource.list ]; then
+  curl -sL https://deb.nodesource.com/setup_6.x | bash -
+  apt-get install nodejs -y
+fi
 
 getent passwd lool || (useradd lool -G sudo; mkdir /home/lool)
 chown lool:lool /home/lool -R
 
-lo_version=$(curl -s http://download.documentfoundation.org/libreoffice/src/5.3.1/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
-wget -c http://download.documentfoundation.org/libreoffice/src/5.3.1/$lo_version.tar.xz -P /opt/
-tar xf /opt/$lo_version.tar.xz -C  /opt/
-mv /opt/$lo_version $ooo
+if [ ! -f ${ooo}/autogen.sh ]; then
+  lo_version=$(curl -s http://download.documentfoundation.org/libreoffice/src/5.3.0/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
+  [ ! -f $lo_version.tar.xz ] && wget -c http://download.documentfoundation.org/libreoffice/src/5.3.0/$lo_version.tar.xz -P /opt/
+  [ ! -d $lo_version ] && tar xf /opt/$lo_version.tar.xz -C  /opt/
+  mv /opt/$lo_version $ooo
+  chown lool:lool $ooo -R
+fi
 
-chown lool:lool $ooo -R
+###############################################################################
 
 sudo -H -u lool bash -c "for dir in ./ ; do (cd "$ooo" && $ooo/autogen.sh --without-help --without-myspell-dicts); done" | tee -a $log_file
 sudo -H -u lool bash -c "for dir in ./ ; do (cd "$ooo" && make); done" | tee -a $log_file
 
 poco_version=$(curl -s https://pocoproject.org/ | grep -oiE 'The latest stable release is [0-9+]\.[0-9\.]{1,}[0-9]{1,}' | awk '{print $NF}')
 poco="/opt/poco-${poco_version}-all"
-wget -c https://pocoproject.org/releases/poco-${poco_version}/poco-${poco_version}-all.tar.gz -P /opt/
-tar xf /opt/poco-${poco_version}-all.tar.gz -C  /opt/
-chown lool:lool $poco -R
+if [ ! -d $poco ]; then
+  [ ! -f /opt/poco-${poco_version}-all.tar.gz ] &&\
+  wget -c https://pocoproject.org/releases/poco-${poco_version}/poco-${poco_version}-all.tar.gz -P /opt/
+  tar xf /opt/poco-${poco_version}-all.tar.gz -C  /opt/
+  chown lool:lool $poco -R
+fi
 
 sudo -H -u lool bash -c "for dir in ./ ; do (cd "$poco" && ./configure); done" | tee -a $log_file
 sudo -H -u lool bash -c  "for dir in ./ ; do (cd "$poco" && make -j$cpu); done" | tee -a $log_file
@@ -94,7 +101,7 @@ PASSWORD=$(randpass 10 0)
 cat <<EOT > /lib/systemd/system/loolwsd.service
 
 [Unit]
-Description=LibreOffice On-Line WebSocket Daemon
+Description=LibreOffice OnLine WebSocket Daemon
 After=network.target
 
 [Service]
@@ -105,21 +112,24 @@ PermissionsStartOnly=true
 ExecStart=${oo}/loolwsd --o:sys_template_path=${oo}/systemplate --o:lo_template_path=${ooo}/instdir  --o:child_root_path=${oo}/jails --o:storage.filesystem[@allow]=true --o:admin_console.username=admin --o:admin_console.password=$PASSWORD
 User=lool
 KillMode=control-group
-Restart=always
+# Restart=always
 
 [Install]
 WantedBy=multi-user.target
 EOT
 
-mkdir /etc/loolwsd
-openssl genrsa -out /etc/loolwsd/key.pem 4096
-openssl req -out /etc/loolwsd/cert.csr -key /etc/loolwsd/key.pem -new -sha256 -nodes -subj "/C=DE/OU=onlineoffice-install.com/CN=onlineoffice-install.com/emailAddress=nomail@nodo.com"
-openssl x509 -req -days 365 -in /etc/loolwsd/cert.csr -signkey /etc/loolwsd/key.pem -out /etc/loolwsd/cert.pem
-openssl x509 -req -days 365 -in /etc/loolwsd/cert.csr -signkey /etc/loolwsd/key.pem -out /etc/loolwsd/ca-chain.cert.pem
-
-ln /lib/systemd/system/loolwsd.service /etc/systemd/system/loolwsd.service
-systemctl enable loolwsd.service
-
+if [ ! -f /etc/loolwsd/ca-chain.cert.pem ]; then
+  mkdir /etc/loolwsd
+  openssl genrsa -out /etc/loolwsd/key.pem 4096
+  openssl req -out /etc/loolwsd/cert.csr -key /etc/loolwsd/key.pem -new -sha256 -nodes -subj "/C=DE/OU=onlineoffice-install.com/CN=onlineoffice-install.com/emailAddress=nomail@nodo.com"
+  openssl x509 -req -days 365 -in /etc/loolwsd/cert.csr -signkey /etc/loolwsd/key.pem -out /etc/loolwsd/cert.pem
+  openssl x509 -req -days 365 -in /etc/loolwsd/cert.csr -signkey /etc/loolwsd/key.pem -out /etc/loolwsd/ca-chain.cert.pem
+fi
+if [! -e /etc/systemd/system/loolwsd.service ]; then
+  ln /lib/systemd/system/loolwsd.service /etc/systemd/system/loolwsd.service
+  systemctl enable loolwsd.service
+fi
+### Testing loolwsd ###
 dialog --backtitle "Information" \
 --title "Note" \
 --msgbox 'The installation log file is in '"${log_file}"'. After reboot you can use loolwsd.service using: systemctl (start,stop or status) loolwsd.service.

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -139,7 +139,7 @@ fi
  # Idempotence : do not recompile loolwsd, install & test if already done
 if [ -f ${lool_dir}/loolwsd ] && ! ${lool_forcebuild}; then
   # leave if loowsd is already compiled and lool_forcebuild is not true.
-  echo "Loolwsd is already compiled and I'm not forced to recompile.\nLeaving here..."
+  echo -e "Loolwsd is already compiled and I'm not forced to recompile.\nLeaving here..."
   exit 1
 fi
 
@@ -158,7 +158,7 @@ fi
 cd ${lool_dir}
 [ -f ${lool_dir}/loolwsd ] && sudo -u lool make clean
 sudo -u lool ./autogen.sh
-[ -z "${lool_logfile}" ] && lool_configure_opts="${lool_configure_opts} --with-logfile=${lool_logfile}"
+[ -n "${lool_logfile}" ] && lool_configure_opts="${lool_configure_opts} --with-logfile=${lool_logfile}"
 sudo -u lool bash -c "./configure --enable-silent-rules --with-lokit-path=${lool_dir}/bundled/include --with-lo-path=${lo_dir}/instdir --with-max-connections=$lool_maxcon --with-max-documents=$lool_maxdoc --with-poco-includes=/usr/local/include --with-poco-libs=/usr/local/lib ${lool_configure_opts}" | tee -a $log_file
 # loolwsd+loleaflet take around 8.5/${cpu} minutes to compile on fast cpu
 sudo -u lool bash -c "make -j$cpu --directory=${lool_dir}" | tee -a $log_file
@@ -176,7 +176,7 @@ make install | tee -a $log_file
 mkdir -p /usr/local/var/cache/loolwsd && chown -R lool:lool /usr/local/var/cache/loolwsd
 
 # create log file for lool user
-[ -z "${lool_logfile}" ] && [ ! -f ${lool_logfile} ] && touch ${lool_logfile}
+[ -n "${lool_logfile}" ] && [ ! -f ${lool_logfile} ] && touch ${lool_logfile}
 chown lool:lool ${lool_logfile}
 
 if [ ! -f /lib/systemd/system/loolwsd.service ]; then

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -198,6 +198,8 @@ mkdir -p /usr/local/var/cache/loolwsd && chown -R lool:lool /usr/local/var/cache
 # create log file for lool user
 [ -n "${lool_logfile}" ] && [ ! -f ${lool_logfile} ] && touch ${lool_logfile}
 chown lool:lool ${lool_logfile}
+# create the hello-world file for test & demo
+sudo -Hu lool cp ${lool_dir}/test/data/hello.odt ${lool_dir}/test/data/hello-world.odt
 
 if [ ! -f /lib/systemd/system/loolwsd.service ]; then
   PASSWORD=$(randpass 10 0)

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -89,9 +89,6 @@ git clone https://github.com/husisusi/online $oo
 chown lool:lool $oo -R
 sudo -H -u lool bash -c "for dir in ./ ; do (cd "$oo" && libtoolize && aclocal && autoheader && automake --add-missing && autoreconf); done"
 
-for dir in ./ ; do (cd "$oo" && npm install -g npm); done
-for dir in ./ ; do (cd "$oo" && npm install -g jake); done
-
 for dir in ./ ; do ( cd "$oo" && ./configure --enable-silent-rules --with-lokit-path=${oo}/bundled/include --with-lo-path=${ooo}/instdir --with-max-connections=$maxcon --with-max-documents=$maxdoc --with-poco-includes=/usr/local/include --with-poco-libs=/usr/local/lib --enable-debug && make -j$cpu --directory=$oo); done | tee -a $log_file
 for dir in ./ ; do ( cd "$oo" && make install); done | tee -a $log_file
 
@@ -102,6 +99,10 @@ chown -R lool:lool {$ooo,$poco,$oo}
 
 PASSWORD=$(randpass 10 0)
 
+if ! npm -g list jake >/dev/null; then
+  npm install -g npm
+  npm install -g jake
+fi
 mkdir -p /usr/local/var/cache/loolwsd && chown -R lool:lool /usr/local/var/cache/loolwsd
 
 if [ ! -f /lib/systemd/system/loolwsd.service ]; then


### PR DESCRIPTION
The script has been improved in various ways to get closer to production requirements  but is still retro-compatible for previous use.
### Major changes:

- LibreOffice major/stable version can be specified or detected in repository
- Build options for Loolwsd
  - enabled-debug added as anoption
  - changed default log file to /var/log/loolwsd.log
- Added **idempotence** to most task.
  - the script is able to be run several times on the same host and only alter what can be changed.
- Changed how the dialog behave:
  - Only appears if LibreOffice has to be compiled
  - Show an estimated compilation time depending on number of core available
- Changed Installation & test step:
  - only run after a Loolwsd successfull compilation
  - test step do not requires sudo privileges anymore.
- Changed log generation:
  - log file has a Date (YYYYMMDD-HHMM) Prefix
  - All the script's output but the dialog prompt is now logged, stderr included
### Misc
- more parameters:
  - `lo_src_repo` & `lo_version` for choosing a libreoffice version to use
  - **added** `sh_interactive `variable to toggle dialog (for scripting use)
  - `lo_forcebuild` & `lool_forcebuild` to force compilation.
- Renamed somes variable for easy-to-recognize names
- "Structural" comments && average compilation time for lo, poco & loolwsd
