### PR TITLE
systemd: make sure cache dir exists on start

### DIFF
--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -96,6 +96,9 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/loolwsd
+ExecStartPre=/bin/mkdir -p /usr/local/var/cache/loolwsd
+ExecStartPre=/bin/chown lool: /usr/local/var/cache/loolwsd
+PermissionsStartOnly=true
 ExecStart=/opt/online/loolwsd --o:sys_template_path=/opt/online/systemplate --o:lo_template_path=/opt/libreoffice/instdir  --o:child_root_path=/opt/online/jails --o:storage.filesystem[@allow]=true --o:admin_console.username=admin --o:admin_console.password=$PASSWORD
 User=lool
 KillMode=control-group


### PR DESCRIPTION
After rebooting my lxc container, the cache dir was not there anymore.

Now systemd makes sure, it exists before starting the service.