### PR TITLE
2.1.0 : Add RAM & space requirements for the host

### DIFF
--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -21,6 +21,7 @@ randpass() {
 clear
 ###############################################################################
 ################################# Parameters ##################################
+###############################################################################
 ### Script parameters ###
 soli="/etc/apt/sources.list"
 cpu=$(nproc)
@@ -43,9 +44,23 @@ lool_maxdoc=100
 
 ###############################################################################
 ############################# System preparation ##############################
+################################# OPERATIONS ##################################
+###############################################################################
 #clear the logs in case of super multi fast script run.
 [ -f ${log_file} ] && rm ${log_file}
 {
+###############################################################################
+############################ System Requirements ##############################
+echo "Verifying System Requirements:"
+### Test RAM size (4GB min) ###
+mem_available=$(grep MemTotal /proc/meminfo| grep -o '[0-9]\+')
+if [ ${mem_available} -lt 4000000 ]; then
+  echo "Error: The system do not meet the minimum requirements." >&2
+  echo "Error: 4GB RAM required!" >&2
+  exit 1
+else
+  echo "Memory: OK ($((mem_available/1024)) MiB)"
+fi
 # run apt update && upgrade if last update is older than 1 day
 find /var/lib/apt/lists/ -mtime -1 |grep -q partial || apt-get update && apt-get upgrade -y
 
@@ -105,6 +120,7 @@ if [ ! -d ${lo_dir}/instdir ] || ${lo_forcebuild}; then
   sudo -Hu lool ./autogen.sh --without-help --without-myspell-dicts
   [ $? -ne 0 ] && exit 2
   # libreoffice take around 8/${cpu} hours to compile on fast cpu.
+  ${lo_forcebuild} && sudo -Hu lool make clean
   sudo -Hu lool make
   [ $? -ne 0 ] && exit 2
   } > >(tee -a ${log_file}) 2> >(tee -a ${log_file} >&2)

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -138,7 +138,7 @@ fi
 # run apt update && upgrade if last update is older than 1 day
 find /var/lib/apt/lists/ -mtime -1 |grep -q partial || apt-get update && apt-get upgrade -y
 
-[ ${sh_interactive} ] && apt-get install dialog -y
+${sh_interactive} && apt-get install dialog -y
 
 grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get update
 
@@ -182,7 +182,7 @@ fi
 
 # build LibreOffice if it has'nt been built already or lo_forcebuild is true
 if [ ! -d ${lo_dir}/instdir ] || ${lo_forcebuild}; then
-  if [ ${sh_interactive} ]; then
+  if ${sh_interactive}; then
     dialog --backtitle "Information" \
     --title "${lo_version} is going to be built." \
     --msgbox "THE COMPILATION WILL TAKE REALLY A VERY LONG TIME,\nAROUND $((16/${cpu})) HOURS (Depending on your CPU's speed),\n"\
@@ -216,7 +216,7 @@ fi
 ## test if the poco library has already been compiled
 # (the dir size should be around 450000ko vs 65000ko when just extracted)
 # so let say arbitrary : do compilation when folder size is less than 100Mo
-if [ $(du -s ${poco_dir} | awk '{print $1}') -lt 100000 ]; then
+if [ $(du -s ${poco_dir} | awk '{print $1}') -lt 100000 ] || ${poco_forcebuild}; then
   cd "$poco_dir"
   sudo -Hu lool ./configure
   [ $? -ne 0 ] && exit 3
@@ -324,7 +324,7 @@ if [! -e /etc/systemd/system/loolwsd.service ]; then
 fi
 } > >(tee -a ${log_file}) 2> >(tee -a ${log_file} >&2)
 ### Testing loolwsd ###
-if [ ${sh_interactive} ]; then
+if ${sh_interactive}; then
   PASSWORD=$(awk -F'password=' '{printf $2}' /lib/systemd/system/loolwsd.service )
   dialog --backtitle "Information" \
   --title "Note" \

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -114,7 +114,7 @@ declare -A mountPointArray # declare associative array
 if [ ! -d ${lo_dir}/instdir ]; then
   mountPointArray["$lo_fs"]=$((mountPointArray["$lo_fs"]+$lo_req_vol))
 fi
-if [ $(du -s ${poco_dir} | awk '{print $1}') -lt 100000 ]; then
+if [ ! -d ${poco_dir} ] || [ $(du -s ${poco_dir} | awk '{print $1}' 2>/dev/null) -lt 100000 ]; then
   mountPointArray["$poco_fs"]=$((mountPointArray["$poco_fs"]+$poco_req_vol))
 fi
 if [ ! -f ${lool_dir}/loolwsd ]; then

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -18,6 +18,40 @@ randpass() {
   [ "$2" == "0" ] && CHAR="[:alnum:]" || CHAR="[:graph:]"
   cat /dev/urandom 2>/dev/null | tr -cd "$CHAR" 2>/dev/null | head -c ${1:-32}
 }
+getFilesystem() {
+  # function return the filesystem of a folder
+  # arg 1 is an existing folder
+  [ ! -d $1 ] &&  echo "error: $1 do not exists or is not a valid directory." >&2 && return 1
+  echo $(df --output=source $1 | tail -1)
+  return 0
+}
+checkAvailableSpace() {
+  # function check if the required space is available and create an error if the requirement is not satisfied
+  # take 2 args :
+    # arg1 : a file system/block file like /dev/sda1
+    # arg2 : required space in MB
+  # return:
+    # stdout: available disk space in MB
+    # stderr: error message.
+    # rc1 if not enought space is available
+    # rc2 bad parameters
+  [ $# -ne 2 ] && return 2
+  local CompFs=$1
+  local CompRequirement=$2
+  # check the arguments:
+  [ ! -b ${CompFs} ] && echo "Error: ${CompFs} is not a valid filesystem" >&2 && return 2
+  availableMB=$(df -m --output=avail ${CompFs}|tail -1)
+  if [ ${availableMB} -lt ${CompRequirement} ]; then
+    echo "${CompFs}: FAILED"
+    echo "Not Enough space available on ${CompName} (${CompRequirement} MiB required)" >&2
+    echo "(only ${availableMB} MiB available)" >&2
+    echo "Exiting." >&2
+    return 1
+  else
+    echo "${availableMB}"
+  fi
+  return 0
+}
 clear
 ###############################################################################
 ################################# Parameters ##################################
@@ -32,7 +66,13 @@ sh_interactive=true
 lo_src_repo='http://download.documentfoundation.org/libreoffice/src'
 lo_version='' #5.3.1.2
 lo_dir="/opt/libreoffice"
-lo_forcebuild=false
+lo_forcebuild=false # force compilation
+lo_req_vol=12000 # minimum space required for LibreOffice compilation, in MB
+
+### POCO parameters ###
+poco_version=$(curl -s https://pocoproject.org/ | grep -oiE 'The latest stable release is [0-9+]\.[0-9\.]{1,}[0-9]{1,}' | awk '{print $NF}')
+poco_dir="/opt/poco-${poco_version}-all"
+poco_req_vol=510 # minimum space required for Poco compilation, in MB
 
 ### LibreOffice Online parameters ###
 lool_dir="/opt/online"
@@ -41,9 +81,9 @@ lool_logfile='/var/log/loolwsd.log'
 lool_forcebuild=false
 lool_maxcon=200
 lool_maxdoc=100
+lool_req_vol=600 # minimum space required for LibreOffice Online compilation, in MB
 
 ###############################################################################
-############################# System preparation ##############################
 ################################# OPERATIONS ##################################
 ###############################################################################
 #clear the logs in case of super multi fast script run.
@@ -61,6 +101,39 @@ if [ ${mem_available} -lt 4000000 ]; then
 else
   echo "Memory: OK ($((mem_available/1024)) MiB)"
 fi
+### Calculate required disk space per file system ###
+# find the target filesystem for each sw and add the required space for this FS
+# on an array BUT only if no build have been done yet.
+lo_fs=$(getFilesystem $(dirname $lo_dir)) || exit 1
+poco_fs=$(getFilesystem /opt) || exit 1
+lool_fs=$(getFilesystem $(dirname $lool_dir)) || exit 1
+#here we use an array to store a relative number of FS and their respective required volume
+#if, like in the default, LO, poco & LOOL are all stored on the same FS, the value add-up
+declare -A mountPointArray # declare associative array
+if [ ! -d ${lo_dir}/instdir ]; then
+  mountPointArray["$lo_fs"]=$((mountPointArray["$lo_fs"]+$lo_req_vol))
+fi
+if [ $(du -s ${poco_dir} | awk '{print $1}') -lt 100000 ]; then
+  mountPointArray["$poco_fs"]=$((mountPointArray["$poco_fs"]+$poco_req_vol))
+fi
+if [ ! -f ${lool_dir}/loolwsd ]; then
+  mountPointArray["$lool_fs"]=$((mountPointArray["$poco_fs"]+$lool_req_vol))
+fi
+# test if each file system used have the required space.
+# if there's nothing to (force-)build (so 0 FS to verify), the script leave here.
+if [ ${#mountPointArray[@]} -ne 0 ]; then
+  for fs_item in "${!mountPointArray[@]}"; do
+    fs_item_avail=$(checkAvailableSpace $fs_item ${mountPointArray["$fs_item"]}) || exit 1
+    echo "${fs_item}: PASSED (${mountPointArray["$fs_item"]} MiB Req., ${fs_item_avail} MiB avail.)"
+  done
+elif ! $lo_forcebuild && ! $lool_forcebuild; then
+  echo "Nothing to build here..."
+  exit 0
+fi
+
+###############################################################################
+############################# System preparation ##############################
+###### Checking system requirement
 # run apt update && upgrade if last update is older than 1 day
 find /var/lib/apt/lists/ -mtime -1 |grep -q partial || apt-get update && apt-get upgrade -y
 
@@ -129,23 +202,21 @@ fi
 ###############################################################################
 ############################# Poco Installation ###############################
 {
-poco_version=$(curl -s https://pocoproject.org/ | grep -oiE 'The latest stable release is [0-9+]\.[0-9\.]{1,}[0-9]{1,}' | awk '{print $NF}')
-poco="/opt/poco-${poco_version}-all"
-if [ ! -d $poco ]; then
+if [ ! -d $poco_dir ]; then
   [ ! -f /opt/poco-${poco_version}-all.tar.gz ] &&\
   wget -c https://pocoproject.org/releases/poco-${poco_version}/poco-${poco_version}-all.tar.gz -P /opt/
   tar xf /opt/poco-${poco_version}-all.tar.gz -C  /opt/
-  chown lool:lool $poco -R
+  chown lool:lool $poco_dir -R
 fi
 } > >(tee -a ${log_file}) 2> >(tee -a ${log_file} >&2)
 
 ######## Poco Build ########
 {
-## test if the poco poco has already been compiled
+## test if the poco library has already been compiled
 # (the dir size should be around 450000ko vs 65000ko when just extracted)
 # so let say arbitrary : do compilation when folder size is less than 100Mo
-if [ $(du -s ${poco} | awk '{print $1}') -lt 100000 ]; then
-  cd "$poco"
+if [ $(du -s ${poco_dir} | awk '{print $1}') -lt 100000 ]; then
+  cd "$poco_dir"
   sudo -Hu lool ./configure
   [ $? -ne 0 ] && exit 3
   sudo -Hu lool make -j${cpu}

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -72,6 +72,7 @@ lo_req_vol=12000 # minimum space required for LibreOffice compilation, in MB
 ### POCO parameters ###
 poco_version=$(curl -s https://pocoproject.org/ | grep -oiE 'The latest stable release is [0-9+]\.[0-9\.]{1,}[0-9]{1,}' | awk '{print $NF}')
 poco_dir="/opt/poco-${poco_version}-all"
+poco_forcebuild=false
 poco_req_vol=510 # minimum space required for Poco compilation, in MB
 
 ### LibreOffice Online parameters ###
@@ -126,7 +127,7 @@ if [ ${#mountPointArray[@]} -ne 0 ]; then
     fs_item_avail=$(checkAvailableSpace $fs_item ${mountPointArray["$fs_item"]}) || exit 1
     echo "${fs_item}: PASSED (${mountPointArray["$fs_item"]} MiB Req., ${fs_item_avail} MiB avail.)"
   done
-elif ! $lo_forcebuild && ! $lool_forcebuild; then
+elif ! $lo_forcebuild && ! $lool_forcebuild && ! $poco_forcebuild; then
   echo "Nothing to build here..."
   exit 0
 fi
@@ -219,6 +220,7 @@ if [ $(du -s ${poco_dir} | awk '{print $1}') -lt 100000 ]; then
   cd "$poco_dir"
   sudo -Hu lool ./configure
   [ $? -ne 0 ] && exit 3
+  $poco_forcebuild && sudo -Hu lool make clean
   sudo -Hu lool make -j${cpu}
   [ $? -ne 0 ] && exit 3
   # poco take around 22/${cpu} minutes to compile on fast cpu

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#VERSION 2.0.1
+#VERSION 2.1.0
 #Written by: Subhi H. & Marc C.
 #Github Contributors: Aalaesar, Kassiematis, morph027
 #This script is free software: you can redistribute it and/or modify it under


### PR DESCRIPTION
The script wil now test the host for 2 requirements before running.
If any requirement if not met, the script will fail before running compilations.
### Requirements:
* 4GB of Ram installed on the host
* Available space calculated:
  * If any component has to be built for the first time
  * by component to build on a filesystem/partition. Ex: if LibreOffice is built on a different partition than Poco and Lool, each partition's free space  is cheched according on what's built on it.

### Added
* `poco_forcebuild` to be homogenous with `lo_forcebuild `and `lool_forcebuild`

### Limitation
It doesn't test the space required to install the dependencies