### PR TITLE
2.2.0 - Change source selection for loowsd+ readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ Script intended to build & install Office Online on Ubuntu 16.04 and Debian 8.7 
 Written by: Subhi H. & Marc C.
 
 ----
+
+## Summary
+* [GNUv3 Licence](#gnuv3-licence)
+* [Requirements](#requirements)
+* [Notice](#notice)
+* [Default Installation](#default-installation)
+* [Idempotence](#idempotence)
+* [Parameters](#parameters)
+  * [LibreOffice](#libreoffice)
+  * [Poco](#poco)
+  * [Lool](#lool)
+    * [Sources status](#sources-status)
+    * [Compilation options](#compilation-options)
+* [Nota Bene](#nota-bene)
+
 ## GNUv3 Licence
 > This script is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 > This script is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
@@ -26,7 +41,7 @@ It will install libreoffice in `/opt/libreoffice`, Poco in `/opt/poco` and onlin
 
 Your can manage your service using systemd: `systemctl start|stop|restart|status loolwsd.service`
 
-### Idempotence
+## Idempotence
 This script has been made idempotent: Only the required action will be executed if it is run several times on the same System in order to get to the expected state.
 
 _Example_: when updating **LibreOffice** online to the latest version, **LibreOffice** compilation and installation steps will not be run as it is already installed.
@@ -74,7 +89,9 @@ The following parameters are options passed to the configuration script before c
 - `lool_configure_opts`: free form string to add even more options ! _`--enable-debug` by default_. **For experts only!**
 
 ## Nota Bene
-- All the script's output is logged in the file `/tmp/YYYYMMDD-HHmm_officeonline.log`. where `YYYYMMDD-HHmm` is the date (to the minute) when the script as been launched.
+- All the script's output is logged in the file `/tmp/YYYYMMDD-HHmm_officeonline.log`. where `YYYYMMDD-HHmm` is the date at the minute the script as been launched.
+
+- `Maxdoc` & `Maxcon` are built-in limitations in WebSocket and intended to guarantee a good QoS and limit resources consumption on the host. *If you intend to change this parameters, take into account that __1 doc opened is around 20MB of RAM used.__*
 
 - Default parameters are values chosen by the maintainers of this script and not default values used by the softwares compiled here.
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,83 @@
 # officeonline-install.sh
-
-Script to install Office Online on Ubuntu 16.04 and Debian 8.7 
+---
+Script intended to build & install Office Online on Ubuntu 16.04 and Debian 8.7 systems.
 
 Written by: Subhi H. & Marc C.
 
+----
+## GNUv3 Licence
 > This script is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 > This script is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
 
-**THE INSTALLATION WILL TAKE REALLY VERY LONG TIME SO BE PATIENT PLEASE!!!**
+## Requirements
+- The script requires a **minimum of 3.7 GB of RAM installed** to run.
+- First installation requires about **13 GB** of available space on the system.
 
-You might encounter errors during the installation, just ignore them.
+## Notice
+**THE FIRST INSTALLATION WILL TAKE A VERY, VERY LONG TIME!**
 
-It will install libreoffice in ```/opt/libreoffice```, Poco in ```/opt/poco``` and onlineOffice in ```/opt/online```
+... So take your favorite mug, and make yourself a nice cup of coffee/tea while you go watching your favorites movies. :smile:
 
-Your can manage your service using systemd: ```systemctl start|stop|restart|status loolwsd.service```
+## Default Installation
+You might see errors during the installation, just ignore them.
 
-Enjoy!!!
+It will install libreoffice in `/opt/libreoffice`, Poco in `/opt/poco` and onlineOffice in `/opt/online`
+
+Your can manage your service using systemd: `systemctl start|stop|restart|status loolwsd.service`
+
+### Idempotence
+This script has been made idempotent: Only the required action will be executed if it is run several times on the same System in order to get to the expected state.
+
+_Example_: when updating **LibreOffice** online to the latest version, **LibreOffice** compilation and installation steps will not be run as it is already installed.
+
+## Parameters
+Theses parameters describes the expected state of the system regarding LibreOffice Online installation.
+
+**The installation can be tuned to your needs by changing theses variables.**
+### LibreOffice:
+- `lo_src_repo`: **LibreOffice** sources are downloaded from this location.
+- `lo_version`: **LibreOffice** version to download. _Empty by default_.
+When empty, the script will download the latest stable version available.
+- `lo_dir`: **LibreOffice** sources directory. _`/opt/libreoffice` by default_.
+- `lo_forcebuild`: A **boolean** to override idempotence and force *LibreOffice* compilation and installation. _`false` by default_.
+
+### POCO:
+Poco is an opensource C++ library for network based project. It is required by LibreOffice Online.
+- `poco_version`: a specific version to download, compile and install. _Fetch the latest stable release from  https://pocoproject.org/ by default_.
+- `poco_dir`: The installation directory for poco. _`/opt/poco-${poco_version}-all` by default._
+- `poco_forcebuild`: A **boolean** to override idempotence and force *POCO* compilation and installation. _`false` by default_.
+
+
+### Lool
+Lool (LibreOffice Online) in a project to bring a opensource Office solution for web editing.
+- `lool_dir`: The installation directory for _Lool_. _`/opt/online` by default_.
+- `lool_forcebuild`: A **boolean** to override idempotence and force *LibreOffice Online* compilation and installation. _`false` by default_.
+#### Sources status:
+For Idempotence, Lool's status is defined by its sources' commit id.
+
+_Each update of the sources by the script will trigger a **lool** compilation & installation_
+- the Git repository: `lool_src_repo` _"https://github.com/LibreOffice/online.git"_
+- One of the 3:
+  - `lool_src_branch`: an existing branch name. It pull the latest commit available _`master` by default_
+  - `lool_src_commit`:  the id of a git commit. _`empty` by default_
+  - `lool_src_tag`: a tag in the git repository._`empty` by default_
+
+If more than one is defined, a choice is made:
+- _choice precedence_: **Commit** over **tag** over **branch**
+
+#### Compilation options:
+The following parameters are options passed to the configuration script before compilation.
+- `lool_logfile`: `/var/log/loolwsd.log`
+- `lool_maxdoc`: Maximum number of _simultaneously_ opened documents for Lool. _`100` by default._
+- `lool_maxcon`: Maximum number of _simultaneously_ opened connections for Lool. _`200` by default._
+- `lool_configure_opts`: free form string to add even more options ! _`--enable-debug` by default_. **For experts only!**
+
+## Nota Bene
+- All the script's output is logged in the file `/tmp/YYYYMMDD-HHmm_officeonline.log`. where `YYYYMMDD-HHmm` is the date (to the minute) when the script as been launched.
+
+- Default parameters are values chosen by the maintainers of this script and not default values used by the softwares compiled here.
+
+- If you ever need support for using this script, try to run it first with all parameters at default to get a reference point.
+
+## Enjoy your free Office Online!

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -348,6 +348,7 @@ eval $(SearchGitCommit $SearchGitOpts)
 if [ -f ${lool_dir}/loolwsd ] && $repChanged ; then
   lool_forcebuild=true
 fi
+chmod -R lool:lool ${lool_dir}
 set +e
 if ! npm -g list jake >/dev/null; then
   npm install -g npm

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#VERSION 2.1.0
+#VERSION 2.2.0
 #Written by: Subhi H. & Marc C.
 #Github Contributors: Aalaesar, Kassiematis, morph027
 #This script is free software: you can redistribute it and/or modify it under

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -63,7 +63,7 @@ log_file="/tmp/$(date +'%Y%m%d-%H%M')_officeonline.log"
 sh_interactive=true
 
 ### LibreOffice parameters ###
-lo_src_repo='http://download.documentfoundation.org/libreoffice/src'
+lo_src_repo='http://download.documentfoundation.org/libreoffice'
 lo_version='' #5.3.1.2
 lo_dir="/opt/libreoffice"
 lo_forcebuild=false # force compilation
@@ -160,10 +160,10 @@ chown lool:lool /home/lool -R
 {
 #verify what version need to be downloaded if no version has been defined in config
 if [ -z "${lo_version}" ];then
-  lo_major_v=$(curl -s ${lo_src_repo}/ | grep -oiE '^.*href="([0-9+]\.)+[0-9]/"'| tail -1 | sed 's/.*href="\(.*\)\/"$/\1/')
-  lo_version=$(curl -s ${lo_src_repo}/${lo_major_v}/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
+  lo_stable=$(curl -s ${lo_src_repo}/stable/ | grep -oiE '^.*href="([0-9+]\.)+[0-9]/"'| tail -1 | sed 's/.*href="\(.*\)\/"$/\1/')
+  lo_version=$(curl -s ${lo_src_repo}/src/${lo_stable}/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
 else
-  lo_major_v=$(echo ${lo_version} | cut -d '.' -f1-3)
+  lo_stable=$(echo ${lo_version} | cut -d '.' -f1-3)
 fi
 # check is libreoffice sources are already present and in the correct version
 if [ -d ${lo_dir} ]; then
@@ -173,7 +173,7 @@ if [ -d ${lo_dir} ]; then
 fi
 # download and extract libreoffice source only if not here
 if [ ! -f ${lo_dir}/autogen.sh ]; then
-  [ ! -f $lo_version.tar.xz ] && wget -c ${lo_src_repo}/${lo_major_v}/$lo_version.tar.xz -P /opt/
+  [ ! -f $lo_version.tar.xz ] && wget -c ${lo_src_repo}/src/${lo_stable}/$lo_version.tar.xz -P /opt/
   [ ! -d $lo_version ] && tar xf /opt/$lo_version.tar.xz -C  /opt/
   mv /opt/$lo_version ${lo_dir}
   chown lool:lool ${lo_dir} -R


### PR DESCRIPTION
## Added Source selection
The Lool source are downloaded from the official libreoffice/online git repository
A git can be specified from one of thoses defined parameters:
- a commit id
- a tag name
- a branch (take the latest available commit)

with precedence: commit > tag > branch if more than one is defined.

By default the script uses branch 'master'

## Updated Readme.md
Added Parameters description in the Readme.