### PR TITLE
move old libreoffice folder to /opt

### DIFF
--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -203,7 +203,7 @@ fi
 if [ -d ${lo_dir} ]; then
   lo_local_version="libreoffice-$(grep PACKAGE_VERSION=\' ${lo_dir}/configure | cut -d \' -f 2)"
   # rename the folder if not in the expected verion
-  [ ${lo_local_version} != ${lo_version} ] && mv ${lo_dir} ${lo_local_version}
+  [ ${lo_local_version} != ${lo_version} ] && mv /opt/${lo_dir} ${lo_local_version}
 fi
 ###############################################################################
 ############################ System Requirements ##############################


### PR DESCRIPTION
The script places the old LibreOffice folder in the folder where the script is started from. In my case always in /home/administrator