### PR TITLE
Missing packages debian 8

### DIFF
--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -262,7 +262,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc -y
+ libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -262,7 +262,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf doxygen -y
+ libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -262,7 +262,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils -y
+ libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -263,7 +263,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
  libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
- uuid-runtime bison flex -y
+ uuid-runtime bison flex zip -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -262,7 +262,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf -y
+ libcups2-dev openjdk-7-jdk gperf doxygen -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -260,10 +260,25 @@ ${sh_interactive} && apt-get install dialog -y
 
 grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get update
 
+# Need to checkout Distrib/Release
+apt-get install lsb-release -y
+
+DIST=`lsb_release -si`
+RELEASE=`lsb_release -sr`
+
+DIST_PKGS=""
+if [ "${DIST}" = "Ubuntu" ]; then
+  DIST_PKGS="${DIST_PKGS} openjdk-8-jdk"
+fi
+if [ "${DIST}" = "Debian" ]; then
+  DIST_PKGS="${DIST_PKGS} openjdk-7-jdk"
+fi
+
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
- uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgl1-mesa-dev ant junit4 -y
+ libcups2-dev gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
+ uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgl1-mesa-dev ant junit4 \
+ ${DIST_PKGS} -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -260,7 +260,7 @@ ${sh_interactive} && apt-get install dialog -y
 
 grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get update
 
-apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz -y
+apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz libcups2-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -260,7 +260,7 @@ ${sh_interactive} && apt-get install dialog -y
 
 grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get update
 
-apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz libcups2-dev -y
+apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz libcups2-dev openjdk-7-jdk -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -260,7 +260,9 @@ ${sh_interactive} && apt-get install dialog -y
 
 grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get update
 
-apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz libcups2-dev openjdk-7-jdk -y
+apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
+ libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
+ libcups2-dev openjdk-7-jdk gperf -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -263,7 +263,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
  libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
- uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev -y
+ uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -262,7 +262,8 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev -y
+ libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
+ uuid-runtime bison -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -262,7 +262,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev -y
+ libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -263,7 +263,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
  libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
- uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgl1-mesa-dev -y
+ uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgl1-mesa-dev ant -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -263,7 +263,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
  libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
- uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev -y
+ uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgl1-mesa-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -263,7 +263,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
  libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
- uuid-runtime bison -y
+ uuid-runtime bison flex -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -262,7 +262,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev -y
+ libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -262,7 +262,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev -y
+ libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -263,7 +263,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
  libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
- uuid-runtime bison flex zip -y
+ uuid-runtime bison flex zip libgtk-3-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -263,7 +263,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
  libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
- uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgl1-mesa-dev ant -y
+ uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgl1-mesa-dev ant junit4 -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -263,7 +263,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
  libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
- uuid-runtime bison flex zip libgtk-3-dev -y
+ uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -262,7 +262,7 @@ grep -q '# deb-src' ${soli} && sed -i 's/# deb-src/deb-src/g' ${soli} && apt-get
 
 apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
- libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev -y
+ libcups2-dev openjdk-7-jdk gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev -y
 [ $? -ne 0 ] && exit 1
 apt-get build-dep libreoffice -y
 


### PR DESCRIPTION
If Debian system installed in minimal version then apt may not install recommended or suggested packages.
So we must be sure that we install all of packages needed to build LiO.