### PR TITLE
v2.3 Create sets of branches for core and online 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+loolwsd\.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ before_install:
   - docker pull koalaman/shellcheck
 
 script:
- - docker run -v $(pwd):/project koalaman/shellcheck /project/officeonline-install.sh
+  # ignore errors:
+  # SC2086: Double quote to prevent globbing and word splitting.
+ - docker run -e SHELLCHECK_OPTS="-e SC2086" -v $(pwd):/project koalaman/shellcheck /project/officeonline-install.sh
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+before_install:
+  - docker pull koalaman/shellcheck
+
+script:
+ - docker run -v $(pwd):/project koalaman/shellcheck /project/officeonline-install.sh
+
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_install:
 script:
   # ignore errors:
   # SC2086: Double quote to prevent globbing and word splitting.
- - docker run -e SHELLCHECK_OPTS="-e SC2086" -v $(pwd):/project koalaman/shellcheck /project/officeonline-install.sh
+  # SC2001: See if you can use ${variable//search/replace} instead.
+ - docker run -e SHELLCHECK_OPTS="-e SC2086 -e SC2001" -v $(pwd):/project koalaman/shellcheck /project/officeonline-install.sh
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # officeonline-install.sh
 ---
-Script intended to build & install Office Online on Ubuntu 16.04 and Debian 8.7 systems.
+Script intended to build & install Office Online on Ubuntu 16.04 and Debian 8.8 systems.
 
 Written by: Subhi H. & Marc C.
 
@@ -11,8 +11,12 @@ Written by: Subhi H. & Marc C.
 * [Requirements](#requirements)
 * [Notice](#notice)
 * [Default Installation](#default-installation)
+  * [Sets](#sets)
+  * [Versions](#versions)
+* [Default Installation](#default-installation)
 * [Idempotence](#idempotence)
 * [Parameters](#parameters)
+  * [Sets](#set-parameters)
   * [LibreOffice](#libreoffice)
   * [Poco](#poco)
   * [Lool](#lool)
@@ -20,7 +24,7 @@ Written by: Subhi H. & Marc C.
     * [Compilation options](#compilation-options)
 * [Nota Bene](#nota-bene)
 
-## GNUv3 Licence
+## GNUv3 License
 > This script is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 > This script is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
@@ -41,6 +45,12 @@ It will install libreoffice in `/opt/libreoffice`, Poco in `/opt/poco` and onlin
 
 Your can manage your service using systemd: `systemctl start|stop|restart|status loolwsd.service`
 
+### Sets
+Since v2.1, it is possible to choose a **Set**.
+A set is an duo of branches from both LibreOffice core and online git repositories that are known to create a smooth LO-Online experience.
+
+**By default latest version available of collabora**
+
 ### Versions
 
 Its possible to pin exact version of the services used, like this:
@@ -60,12 +70,28 @@ _Example_: when updating **LibreOffice** online to the latest version, **LibreOf
 These parameters describes the expected state of the system regarding LibreOffice Online installation.
 
 **The installation can be tuned to your needs by changing these variables.**
+
+### Set Parameters:
+- `set_name`: used to locate branchs folders in the libreoffice project. _'collabora' by default_
+- `set_core_regex`: regulax expression used to find the branch name for core _'cp-' by default._
+- `set_online_regex`: regulax expression used to find the branch name for online _'collabora-online' by default._
+- `set_version` can be used **if both** branch name contains a common version number.
+Else, latest version available for each project will be used. _empty by default_
+
 ### LibreOffice:
-- `lo_src_repo`: **LibreOffice** sources are downloaded from this location.
-- `lo_version`: **LibreOffice** version to download. _Empty by default_.
-When empty, the script will download the latest stable version available.
-- `lo_dir`: **LibreOffice** sources directory. _`/opt/libreoffice` by default_.
+For Idempotence, LO's status is defined by its sources' commit id.
+- `lo_dir`: The installation directory for _Lo_. _`/opt/online` by default_.
 - `lo_forcebuild`: A **boolean** to override idempotence and force *LibreOffice* compilation and installation. _`false` by default_.
+- `lo_configure_opts`: free form string to add even more options ! _`--without-help --without-myspell-dicts --without-java` by default_. **For experts only!**
+_Each update of the sources by the script will trigger a **lO** compilation & installation_
+- `lo_src_repo`: the Git repository _"https://github.com/LibreOffice/core.git"_
+- `lo_src_branch`: an existing branch name. It pull the latest Tag available _`master` by default_
+- One of the 2:
+  - `lo_src_commit`:  the id of a git commit in the selected branch. _`empty` by default_
+  - `lo_src_tag`: a tag in the selected branch. _`empty` by default_
+
+If more than one is defined, a choice is made:
+- _choice precedence_: **Commit** over **tag**
 
 ### POCO:
 Poco is an opensource C++ library for network based project. It is required by LibreOffice Online.

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#VERSION 2.2.0
+#VERSION 2.3.0
 #Written by: Subhi H. & Marc C.
 #Github Contributors: Aalaesar, Kassiematis, morph027
 #This script is free software: you can redistribute it and/or modify it under
@@ -167,8 +167,6 @@ SearchGitCommit() {
     #change the remote branch if needed and reset to latestCommit
     latestCommit=$(git log -1 origin/${myBranch}| grep ^commit | awk '{print $NF}')
     [ "${myBranch}" != "${HeadBranch}" ] && echo "git checkout ${myBranch};" && rcode=true
-    # [ ${latestCommit} != ${HeadCommit} ] && echo "git reset --hard ${latestCommit};" && rcode=true
-    # echo "repChanged=$rcode"
     HeadBranch="$myBranch"
     # return 0
   fi
@@ -183,8 +181,6 @@ SearchGitCommit() {
     fi
     #find the commit's long hash from the short hash
     myCommit=$(git log --simplify-by-decoration --decorate --pretty=oneline "origin/$HeadBranch" | grep "$myCommit"|awk '{print $1}')
-    # myCommitBranch=$(git branch --contains ${myCommit}| awk '{print $NF}') # fix for case when found branch is Headbranch
-    # [ "${myCommitBranch}" != "${HeadBranch}" ] && echo "git checkout ${myCommitBranch};" && rcode=true
     [ "${myCommit}" != "${HeadCommit}" ] && echo "git reset --hard ${myCommit};" && rcode=true
     echo "repChanged=$rcode"
     return 0
@@ -199,8 +195,6 @@ SearchGitCommit() {
        return 1
      fi
     myTagCommit=$(git log --simplify-by-decoration --decorate --pretty=oneline "origin/$HeadBranch" | grep -Em 1 "tag:.*$myCommit"|awk '{print $1}')
-    # myTagBranch=$(git branch --contains ${myTagCommit}| awk '{print $NF}')  # fix for case when found branch is Headbranch
-    # [ "${myTagBranch}" != "${HeadBranch}" ] && echo "git checkout ${myTagBranch};" && rcode=true
     [ "${myTagCommit}" != "${HeadCommit}" ] && echo "git reset --hard ${myTagCommit};" && rcode=true
     echo "repChanged=$rcode"
     return 0
@@ -329,21 +323,6 @@ lool_req_vol=650 # minimum space required for LibreOffice Online compilation, in
 #clear the logs in case of super multi fast script run.
 [ -f ${log_file} ] && rm ${log_file}
 {
-# #verify what version of LibreOffice need to be downloaded if no version has been defined in config
-# if [ -z "${lo_version}" ]; then
-#   lo_stable=$(curl -s ${lo_src_repo}/stable/ | grep -oiE '^.*href="([0-9+]\.)+[0-9]/"'| tail -1 | sed 's/.*href="\(.*\)\/"$/\1/')
-#   lo_version=$(curl -s ${lo_src_repo}/src/${lo_stable}/ | grep -oiE 'libreoffice-5.[0-9+]\.[0-9+]\.[0-9]' | awk 'NR == 1')
-# else
-#   lo_stable=$(echo ${lo_version} | cut -d '.' -f1-3)
-#   # FIX when lo_version do not have subtring "libreoffice"
-#   [ ${lo_version:0:5} != "libre" ] && lo_version="libreoffice-${lo_version}"
-# fi
-# # check is libreoffice sources are already present and in the correct version
-# if [ -d ${lo_dir} ]; then
-#   lo_local_version="libreoffice-$(grep PACKAGE_VERSION=\' ${lo_dir}/configure | cut -d \' -f 2)"
-#   # if LO is NOT in the expected version, force the space requirement for it will be rebuilt again.
-#   [ ${lo_local_version} != ${lo_version} ] && lo_updated=true || lo_updated=false
-# fi
 if [ -n "$set_name" ]; then
   echo "Searching for a set named $set_name..."
   my_set=$(FindOnlineSet "$set_name" "$lo_src_repo" "$set_core_regex" "$lool_src_repo" "$set_online_regex" "$set_version")
@@ -437,17 +416,6 @@ chown lool:lool /home/lool -R
 ###############################################################################
 ######################## libreoffice compilation ##############################
 {
-# download and extract libreoffice source only if not here
-# if [ ! -f ${lo_dir}/autogen.sh ]; then
-#   set -e
-#   [ ! -f $lo_version.tar.xz ] && wget -c ${lo_src_repo}/src/${lo_stable}/$lo_version.tar.xz -P "$(dirname ${lo_dir})"/
-#   [ ! -d $lo_version ] && tar xf "$(dirname ${lo_dir})"/$lo_version.tar.xz -C  "$(dirname ${lo_dir})"/
-#   set +e
-#   # rename the folder if not in the expected version
-#   [ ${lo_local_version} != ${lo_version} ] && mv ${lo_dir} "$(dirname ${lo_dir})"/${lo_local_version}
-#   mv "$(dirname ${lo_dir})"/$lo_version ${lo_dir}
-#   chown lool:lool ${lo_dir} -R
-# fi
 set -e
 SearchGitOpts=''
 [ -n "${lo_src_branch}" ] && SearchGitOpts="${SearchGitOpts} -b ${lo_src_branch}"

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -199,12 +199,14 @@ SearchGitCommit() {
     echo "repChanged=$rcode"
     return 0
   else
-    latestTagCommit=$(git log --simplify-by-decoration --decorate --pretty=oneline "origin/$HeadBranch" | grep -Em 1 "tag: "|awk '{print $1}')
+    # if no argument has been given, just get the latest tag of the branch.
+    latestTag=$(git log --simplify-by-decoration --decorate --pretty=oneline "origin/$HeadBranch" | grep -Em 1 "tag: ")
+    latestTagCommit=$(echo "$latestTag"|awk '{print $1}')
+    echo "echo Selected Tag: $(echo ${latestTag} | sed 's/.*tag: \(.*\)[)].*/\1/') ${latestTag:0:7}"
     [ "${latestTagCommit}" != "${HeadCommit}" ] && echo "git reset --hard ${latestTagCommit};" && rcode=true
     echo "repChanged=$rcode"
     return 0
   fi
-  # if no argument has been given, just get the latest commit of the current checked-out branch.
   # this block is for completion as this function is never going to be called without args here.
   if [ -z "${myBranch}${myCommit}${myTag}" ]; then
     latestCommit=$(git log -1 origin/${HeadBranch}| grep ^commit | awk '{print $NF}')
@@ -327,8 +329,8 @@ if [ -n "$set_name" ]; then
   echo "Searching for a set named $set_name..."
   my_set=$(FindOnlineSet "$set_name" "$lo_src_repo" "$set_core_regex" "$lool_src_repo" "$set_online_regex" "$set_version")
   if [ -n "$my_set" ]; then
-    lo_src_branch=$(echo $my_set | awk '{print $1}') && echo "core branch: $lo_src_branch"
-    lool_src_branch=$(echo $my_set | awk '{print $2}') && echo "core branch: $lool_src_branch"
+    lo_src_branch=$(echo $my_set | awk '{print $1}') && echo "Core branch: $lo_src_branch"
+    lool_src_branch=$(echo $my_set | awk '{print $2}') && echo "Online branch: $lool_src_branch"
   fi
 fi
 ###############################################################################
@@ -395,7 +397,7 @@ if [ "${DIST}" = "Debian" ]; then
   DIST_PKGS="${DIST_PKGS} openjdk-7-jdk"
 fi
 
-if ! apt-get install sudo curl libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
+if ! apt-get install sudo curl procps libegl1-mesa-dev libkrb5-dev systemd python-polib git libkrb5-dev make openssl g++ libtool ccache libpng12-0 libpng12-dev libpcap0.8 libpcap0.8-dev \
  libcunit1 libcunit1-dev libpng12-dev libcap-dev libtool m4 automake libcppunit-dev libcppunit-doc pkg-config wget libfontconfig1-dev graphviz \
  libcups2-dev gperf doxygen libxslt1-dev xsltproc libxml2-utils python-dev python3-dev libxt-dev libxrender-dev libxrandr-dev \
  uuid-runtime bison flex zip libgtk-3-dev libgtk2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgl1-mesa-dev ant junit4 nasm \

--- a/officeonline-install.sh
+++ b/officeonline-install.sh
@@ -22,10 +22,10 @@ Options:
     display this help and exit
 
   -l, --libreoffice_commit)=VERSION
-    Libreoffice COMMIT - full hash
+    Libreoffice COMMIT - short/full hash
 
   -o, --libreoffice_online_commit)=COMMIT
-    Libreoffice Online COMMIT - full hash
+    Libreoffice Online COMMIT - short/full hash
 
   -p, --poco_version)=VERSION
     Poco Version


### PR DESCRIPTION
## V2.3.1
- added new "set" functions. Default set is **Collabora**
- Libreoffice is now cloned from the _official github repository_
- Some code Improvement
- By default build core & online  from the latest **tag** of the branch instead of latest _commit_.
- Added Travis integration with **shellcheck** test to validate the script code quality. (**_Activation here Highly recommended !_**)
- **ShellCheck**: quotes and substitution warnings disabled
