### PR TITLE
update for pocoPrep.sh and officeonline-install.cfg

### DIFF
--- a/bin/pocoPrep.sh
+++ b/bin/pocoPrep.sh
@@ -6,9 +6,9 @@
 ## Download & install Poco Sources
 [ -z "$poco_version" ] && poco_version=$poco_version_latest
 [ -z "$poco_dir" ] && poco_dir="/opt/poco-${poco_version}-all"
-poco_version_folder=$(grep -oiE '[0-9+]\.[0-9\.]{1,}[0-9]{1,}' <<<"${poco_version}")
+#poco_version_folder=$(grep -oiE '[0-9+]\.[0-9\.]{1,}[0-9]{1,}' <<<"${poco_version}")
 if [ ! -d $poco_dir ]; then
-  wget -c https://pocoproject.org/releases/poco-${poco_version_folder}/poco-${poco_version}-all.tar.gz -P "$(dirname $poco_dir)"/ || exit 3
+  wget -c https://pocoproject.org/releases/poco-${poco_version}/poco-${poco_version}-all.tar.gz -P "$(dirname $poco_dir)"/ || exit 3
   tar xf "$(dirname $poco_dir)"/poco-${poco_version}-all.tar.gz -C  "$(dirname $poco_dir)"/
   rm -f poco*.tar.gz
   chown cool:cool $poco_dir -R

--- a/officeonline-install.cfg
+++ b/officeonline-install.cfg
@@ -18,7 +18,7 @@ poco_forcebuild=false
 #### LibreOffice Online parameters ###
 cool_src_repo='https://github.com/CollaboraOnline/online.git'
 cool_src_branch='distro/collabora/co-23-05$'
-cool_src_tag='cp-23.05.2-2'
+cool_src_tag='cp-23.05.3-1'
 cool_dir="/opt/cool"
 cool_configure_opts="--disable-werror --with-lokit-path=${lo_dir}/include"
 cool_logfile='/var/log/coolwsd.log'

--- a/officeonline-install.cfg
+++ b/officeonline-install.cfg
@@ -18,7 +18,7 @@ poco_forcebuild=false
 #### LibreOffice Online parameters ###
 cool_src_repo='https://github.com/CollaboraOnline/online.git'
 cool_src_branch='distro/collabora/co-23-05$'
-cool_src_tag='cp-23.05.4-1'
+cool_src_tag='cp-23.05.4-2'
 cool_dir="/opt/cool"
 cool_configure_opts="--disable-werror --with-lokit-path=${lo_dir}/include"
 cool_logfile='/var/log/coolwsd.log'

--- a/officeonline-install.cfg
+++ b/officeonline-install.cfg
@@ -18,7 +18,7 @@ poco_forcebuild=false
 #### LibreOffice Online parameters ###
 cool_src_repo='https://github.com/CollaboraOnline/online.git'
 cool_src_branch='distro/collabora/co-23-05$'
-cool_src_tag='cp-23.05.5-1'
+cool_src_tag='cp-23.05.5-2'
 cool_dir="/opt/cool"
 cool_configure_opts="--disable-werror --with-lokit-path=${lo_dir}/include"
 cool_logfile='/var/log/coolwsd.log'

--- a/officeonline-install.cfg
+++ b/officeonline-install.cfg
@@ -17,8 +17,8 @@ poco_forcebuild=false
 
 #### LibreOffice Online parameters ###
 cool_src_repo='https://github.com/CollaboraOnline/online.git'
-cool_src_branch='distro/collabora/co-23-05$'
-cool_src_tag='cp-23.05.5-2'
+cool_src_branch='distro/collabora/co-23.05'
+#cool_src_tag='cp-23.05.5-2'
 cool_dir="/opt/cool"
 cool_configure_opts="--disable-werror --with-lokit-path=${lo_dir}/include"
 cool_logfile='/var/log/coolwsd.log'

--- a/officeonline-install.cfg
+++ b/officeonline-install.cfg
@@ -18,7 +18,7 @@ poco_forcebuild=false
 #### LibreOffice Online parameters ###
 cool_src_repo='https://github.com/CollaboraOnline/online.git'
 cool_src_branch='distro/collabora/co-23-05$'
-cool_src_tag='cp-23.05.4-2'
+cool_src_tag='cp-23.05.5-1'
 cool_dir="/opt/cool"
 cool_configure_opts="--disable-werror --with-lokit-path=${lo_dir}/include"
 cool_logfile='/var/log/coolwsd.log'

--- a/officeonline-install.cfg
+++ b/officeonline-install.cfg
@@ -18,7 +18,7 @@ poco_forcebuild=false
 #### LibreOffice Online parameters ###
 cool_src_repo='https://github.com/CollaboraOnline/online.git'
 cool_src_branch='distro/collabora/co-23-05$'
-cool_src_tag='cp-23.05.3-1'
+cool_src_tag='cp-23.05.4-1'
 cool_dir="/opt/cool"
 cool_configure_opts="--disable-werror --with-lokit-path=${lo_dir}/include"
 cool_logfile='/var/log/coolwsd.log'


### PR DESCRIPTION
pocoPrep.sh - fixed poco url if version contains letters
officeonline-install.cfg - always use the latest COOL ver